### PR TITLE
Limit geometry size by using the extent

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,7 +17,8 @@
         "waitsFor",
         "describe",
         "xdescribe",
-        "stubModule"
+        "stubModule",
+        "$"
     ],
 
     "evil": true,

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -100,10 +100,10 @@ define([
 
                 this.inherited(arguments);
 
-                // this.login = new LoginRegister({
-                //     appName: AGRC.appName,
-                //     logoutDiv: this.logoutDiv
-                // });
+                this.login = new LoginRegister({
+                    appName: AGRC.appName,
+                    logoutDiv: this.logoutDiv
+                });
             },
             startup: function() {
                 // summary:

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -100,10 +100,10 @@ define([
 
                 this.inherited(arguments);
 
-                this.login = new LoginRegister({
-                    appName: AGRC.appName,
-                    logoutDiv: this.logoutDiv
-                });
+                // this.login = new LoginRegister({
+                //     appName: AGRC.appName,
+                //     logoutDiv: this.logoutDiv
+                // });
             },
             startup: function() {
                 // summary:

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -32,6 +32,10 @@ function(
         //      print task url
         exportWebMapUrl: 'http://mapserv.utah.gov/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task',
 
+        // extentMaxArea: number
+        //      the maximum area of an extent that a report is allowed to be 
+        extentMaxArea: 1210000000,
+
         urls: {
             vector: 'http://mapserv.utah.gov/arcgis/rest/services/BaseMaps/Vector/MapServer',
             mainReport: '/arcgis/rest/services/PEL/Toolbox/GPServer/PEL_Main',

--- a/src/app/templates/ReportGeneratorWizard.html
+++ b/src/app/templates/ReportGeneratorWizard.html
@@ -22,7 +22,10 @@
         </div>
       </div>
       <div class='form-group'>
-        <label class='control-label' data-dojo-attach-point='geometryLabel'>Has Geometry: <span class='glyphicon glyphicon-exclamation-sign' data-dojo-attach-point='geometryStatus'></span></label>
+        <label class='control-label'>Has Geometry: <span class='glyphicon glyphicon-exclamation-sign' data-dojo-attach-point='geometryStatus'></span></label>
+      </div>
+      <div class='form-group'>
+        <label class='control-label'>Geometry Size: <span class='glyphicon glyphicon-exclamation-sign' data-dojo-attach-point='geometrySize'></span></label> <span data-dojo-attach-point='geometryText'></span>
       </div>
       <div class='form-group' data-dojo-attach-point='bufferGroup'>
         <label class='control-label'>Geometry Buffer</label>


### PR DESCRIPTION
This is a nice way to not make requests to the server to get the actual area of a shape. It's fast and it's less intrusive than having to zoom in to an area like the old pel.
